### PR TITLE
fix: support uppercase payment requests

### DIFF
--- a/payreq.js
+++ b/payreq.js
@@ -696,7 +696,17 @@ function encode (inputData, addDefaults) {
 // decode will only have extra comments that aren't covered in encode comments.
 // also if anything is hard to read I'll comment.
 function decode (paymentRequest) {
+  // Ensure not mixed case.
+  const hasUpperCase = paymentRequest && /[A-Z]/.test(paymentRequest)
+  const hasLowerCase = paymentRequest && /[a-z]/.test(paymentRequest)
+  if (hasUpperCase && hasLowerCase) throw new Error('Not a proper lightning payment request (mixed case)')
+
+  // Convert to lowercase.
+  paymentRequest = paymentRequest ? paymentRequest.toLowerCase() : ''
+
+  // Basic sanity check
   if (paymentRequest.slice(0, 2) !== 'ln') throw new Error('Not a proper lightning payment request')
+
   let decoded = bech32.decode(paymentRequest, Number.MAX_SAFE_INTEGER)
   let prefix = decoded.prefix
   let words = decoded.words


### PR DESCRIPTION
According to the bech32 spec, both uppercase and lowercase payment requests are valid. some QR codes use a special mode where they only use UPPER case to encode the data more efficiently.

Here is the relevant part of the spec:

https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#specification

> The lowercase form is used when determining a character's value for checksum purposes.

> Encoders MUST always output an all lowercase Bech32 string. If an uppercase version of the encoding result is desired, (e.g.- for presentation purposes, or QR code use), then an uppercasing procedure can be performed external to the encoding process.

> Decoders MUST NOT accept strings where some characters are uppercase and some are lowercase (such strings are referred to as mixed case strings).

> For presentation, lowercase is usually preferable, but inside QR codes uppercase SHOULD be used, as those permit the use of alphanumeric mode, which is 45% more compact than the normal byte mode.

This PR adds support for decoding uppercase payment requests