### PR TITLE
Alternate Fix: Skip unknown tagged fields

### DIFF
--- a/payreq.js
+++ b/payreq.js
@@ -640,7 +640,8 @@ function encode (inputData, addDefaults) {
   let tags = data.tags
   let tagWords = []
   tags.forEach(tag => {
-    const possibleTagNames = Object.keys(TAGENCODERS).concat([unknownTagName])
+    const possibleTagNames = Object.keys(TAGENCODERS)
+    if (canReconstruct) possibleTagNames.push(unknownTagName)
     // check if the tagName exists in the encoders object, if not throw Error.
     if (possibleTagNames.indexOf(tag.tagName) === -1) {
       throw new Error('Unknown tag key: ' + tag.tagName)

--- a/payreq.js
+++ b/payreq.js
@@ -95,6 +95,20 @@ const TAGPARSERS = {
   '3': routingInfoParser // for extra routing info (private etc.)
 }
 
+const unknownTagName = 'unknownTag'
+
+function unknownEncoder (data) {
+  data.words = bech32.decode(data.words, Number.MAX_SAFE_INTEGER).words
+  return data
+}
+
+function getUnknownParser (tagCode) {
+  return (words) => ({
+    tagCode: parseInt(tagCode),
+    words: bech32.encode('unknown', words, Number.MAX_SAFE_INTEGER)
+  })
+}
+
 function wordsToIntBE (words) {
   return words.reverse().reduce((total, item, index) => {
     return total + item * Math.pow(32, index)
@@ -626,14 +640,24 @@ function encode (inputData, addDefaults) {
   let tags = data.tags
   let tagWords = []
   tags.forEach(tag => {
+    const possibleTagNames = Object.keys(TAGENCODERS).concat([unknownTagName])
     // check if the tagName exists in the encoders object, if not throw Error.
-    if (Object.keys(TAGENCODERS).indexOf(tag.tagName) === -1) {
+    if (possibleTagNames.indexOf(tag.tagName) === -1) {
       throw new Error('Unknown tag key: ' + tag.tagName)
     }
-    // each tag starts with 1 word code for the tag
-    tagWords.push(TAGCODES[tag.tagName])
-    let encoder = TAGENCODERS[tag.tagName]
-    let words = encoder(tag.data)
+
+    let words
+    if (tag.tagName !== unknownTagName) {
+      // each tag starts with 1 word code for the tag
+      tagWords.push(TAGCODES[tag.tagName])
+
+      const encoder = TAGENCODERS[tag.tagName]
+      words = encoder(tag.data)
+    } else {
+      let result = unknownEncoder(tag.data)
+      tagWords.push(result.tagCode)
+      words = result.words
+    }
     // after the tag code, 2 words are used to store the length (in 5 bit words) of the tag data
     // (also left padded, most integers are left padded while buffers are right padded)
     tagWords = tagWords.concat([0].concat(intBEToWords(words.length)).slice(-2))
@@ -765,8 +789,9 @@ function decode (paymentRequest) {
   // we have no tag count to go on, so just keep hacking off words
   // until we have none.
   while (words.length > 0) {
-    tagName = TAGNAMES[words[0].toString()]
-    parser = TAGPARSERS[words[0].toString()]
+    let tagCode = words[0].toString()
+    tagName = TAGNAMES[tagCode] || unknownTagName
+    parser = TAGPARSERS[tagCode] || getUnknownParser(tagCode)
     words = words.slice(1)
 
     tagLength = wordsToIntBE(words.slice(0, 2))

--- a/test/index.js
+++ b/test/index.js
@@ -222,5 +222,18 @@ tape(`can decode and encode payment request containing unknown tags`, (t) => {
 
   const encoded = lnpayreq.encode(decoded)
   t.same(encoded.paymentRequest, paymentRequest)
+
+  // make canReconstruct false
+  // encoding unknown tags should fail if making a new request
+  // if signature and recoveryFlag are present there are checks
+  // to make sure that the data is what is signed
+  // As long as it is impossible to create
+  decoded.signature = undefined
+  decoded.recoveryFlag = undefined
+
+  t.throws(() => {
+    lnpayreq.encode(decoded)
+  }, new RegExp('Unknown tag key: unknownTag'))
+
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -206,3 +206,21 @@ tape(`can decode upper case payment request`, (t) => {
   t.ok(decoded.complete === true)
   t.end()
 })
+
+tape(`can decode and encode payment request containing unknown tags`, (t) => {
+  const paymentRequest = 'lntb30m1pw2f2yspp5s59w4a0kjecw3zyexm7zur8l8' +
+                         'n4scw674w8sftjhwec33km882gsdpa2pshjmt9de6zq' +
+                         'un9w96k2um5ypmkjargypkh2mr5d9cxzun5ypeh2urs' +
+                         'dae8gxqruyqvzddp68gup69uhnzwfj9cejuvf3xshrw' +
+                         'de68qcrswf0d46kcarfwpshyaplw3skw0tdw4k8g6ts' +
+                         'v9e8gu2etcvsym36pdjpz04wm9nn96f9ntc3t3h5r08' +
+                         'pe9d62p3js5wt5rkurqnrl7zkj2fjpvl3rmn7wwazt8' +
+                         '0letwxlm22hngu8n88g7hsp542qpl'
+
+  const decoded = lnpayreq.decode(paymentRequest)
+  t.ok(decoded.complete === true)
+
+  const encoded = lnpayreq.encode(decoded)
+  t.same(encoded.paymentRequest, paymentRequest)
+  t.end()
+})


### PR DESCRIPTION
Alternative to #15 

There should be a way to encode unknown tags so that you can re-encode decoded payment requests.

canReconstruct check should make sure that people do not create random tags, but still allow for decoding and reconstructing with encode.