### PR TITLE
Update coininfo to v4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,7 +327,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -480,8 +480,9 @@
       "dev": true
     },
     "coininfo": {
-      "version": "git+https://github.com/cryptocoinjs/coininfo.git#c7e003b2fc0db165b89e6f98f6d6360ad22616b2",
-      "from": "git+https://github.com/cryptocoinjs/coininfo.git#c7e003b2fc0db165b89e6f98f6d6360ad22616b2",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/coininfo/-/coininfo-4.5.0.tgz",
+      "integrity": "sha512-9YnPekCDaFSJl/yG27dEkCbHF09CO3Cz38A2TMcFZRMcaCy2l38B2nQK/rdz8zLqOLVzzE/e0MpcWMxvyEncGA==",
       "requires": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bech32": "^1.1.2",
     "bitcoinjs-lib": "^3.3.1",
     "bn.js": "^4.11.8",
-    "coininfo": "git+https://github.com/cryptocoinjs/coininfo.git#c7e003b2fc0db165b89e6f98f6d6360ad22616b2",
+    "coininfo": "^4.5.0",
     "lodash": "^4.17.11",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^3.4.0"


### PR DESCRIPTION
Latest release of coininfo now includes bech32 support, so no need for specific pinned commit. Update dependency to latest version.