### PR TITLE
Simnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ var decoded = lightningPayReq.decode('lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zw
     * `bitcoin` - bitcoin, mainnet
     * `testnet` - bitcoin, testnet
     * `regtest` - bitcoin, regtest
+    * `simnet` - bitcoin, simnet
     * `litecoin` - litecoin, mainnet
     * `litecoin_testnet` - litecoin, testnet
 * Alternatively: You can pass the result of decode into encode and it will use the

--- a/package-lock.json
+++ b/package-lock.json
@@ -480,9 +480,8 @@
       "dev": true
     },
     "coininfo": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/coininfo/-/coininfo-4.5.0.tgz",
-      "integrity": "sha512-9YnPekCDaFSJl/yG27dEkCbHF09CO3Cz38A2TMcFZRMcaCy2l38B2nQK/rdz8zLqOLVzzE/e0MpcWMxvyEncGA==",
+      "version": "git+https://github.com/LN-Zap/coininfo.git#d7ac7be9c9c4ee74dada187f7762a55887a9c6ca",
+      "from": "git+https://github.com/LN-Zap/coininfo.git#d7ac7be9c9c4ee74dada187f7762a55887a9c6ca",
       "requires": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bech32": "^1.1.2",
     "bitcoinjs-lib": "^3.3.1",
     "bn.js": "^4.11.8",
-    "coininfo": "^4.5.0",
+    "coininfo": "https://github.com/LN-Zap/coininfo#d7ac7be9c9c4ee74dada187f7762a55887a9c6ca",
     "lodash": "^4.17.11",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^3.4.0"

--- a/payreq.js
+++ b/payreq.js
@@ -13,6 +13,7 @@ const BITCOINJS_NETWORK_INFO = {
   bitcoin: coininfo.bitcoin.main.toBitcoinJS(),
   testnet: coininfo.bitcoin.test.toBitcoinJS(),
   regtest: coininfo.bitcoin.regtest.toBitcoinJS(),
+  simnet: coininfo.bitcoin.simnet.toBitcoinJS(),
   litecoin: coininfo.litecoin.main.toBitcoinJS(),
   litecoin_testnet: coininfo.litecoin.test.toBitcoinJS()
 }
@@ -35,6 +36,7 @@ const BECH32CODES = {
   bc: 'bitcoin',
   tb: 'testnet',
   bcrt: 'regtest',
+  sb: 'simnet',
   ltc: 'litecoin',
   tltc: 'litecoin_testnet'
 }


### PR DESCRIPTION
As a follow up to https://github.com/bitcoinjs/bolt11/issues/19 this PR updates coininfo package to a version that supports simnet and adds simnet support into the bolt11 library itself.

This makes it easier to use with simnet as the user doesn't need to do manually parse the payment request and figure out which bech32 code they need to manually pass into the decode method.