### PR TITLE
replace crypto with create-hash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "bitcoinjs-lib": "^3.3.1",
     "bn.js": "^4.11.8",
     "coininfo": "^4.5.0",
+    "create-hash": "^1.2.0",
     "lodash": "^4.17.11",
     "safe-buffer": "^5.1.1",
     "secp256k1": "^3.4.0"

--- a/payreq.js
+++ b/payreq.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const createHash = require('create-hash')
 const bech32 = require('bech32')
 const secp256k1 = require('secp256k1')
 const Buffer = require('safe-buffer').Buffer
@@ -128,7 +128,7 @@ function intBEToWords (intBE, bits) {
 }
 
 function sha256 (data) {
-  return crypto.createHash('sha256').update(data).digest()
+  return createHash('sha256').update(data).digest()
 }
 
 function convert (data, inBits, outBits) {


### PR DESCRIPTION
The nodejs `crypto` package is only being used to create hashes, but then this package doesn't work on browsers unless some complicated shim stuff is done.

The `create-hash` package has the same API as `crypto.createHash` and uses the same nodejs `crypto` when available, but uses its own pure-JS thing when in browsers or browser-like environments like react-native.

Plus: it was also already being included by some deep dependency.