### PR TITLE
chore: upgrade to bitcoinjs-lib v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ var decoded = lightningPayReq.decode('lnbc20u1pvjluezhp58yjmdan79s6qqdhdzgynm4zw
     "bech32": "bc",
     "pubKeyHash": 0,
     "scriptHash": 5,
-    "validWitnessVersions": [
-      0
-    ]
+    "validWitnessVersions": [0, 1]
   },
   "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
   "paymentRequest": "lnbc20u1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppqw508d6qejxtdg4y5r3zarvary0c5xw7kxqrrsssp5m6kmam774klwlh4dhmhaatd7al02m0h0m6kmam774klwlh4dhmhs9qypqqqcqpf3cwux5979a8j28d4ydwahx00saa68wq3az7v9jdgzkghtxnkf3z5t7q5suyq2dl9tqwsap8j0wptc82cpyvey9gf6zyylzrm60qtcqsq7egtsq",
@@ -150,7 +148,7 @@ var encoded = lightningPayReq.encode({
     "bech32": "bc",
     "pubKeyHash": 0,
     "scriptHash": 5,
-    "validWitnessVersions": [0]
+    "validWitnessVersions": [0, 1]
   },
   "satoshis": 2000,
   "timestamp": 1496314658,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bolt11",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,9 +300,9 @@
       "dev": true
     },
     "base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -312,15 +312,15 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
       "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
     },
-    "bigi": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
-      "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
-    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip174": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
     },
     "bip66": {
       "version": "1.1.5",
@@ -330,31 +330,25 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "bitcoin-ops": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-    },
     "bitcoinjs-lib": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
-      "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.0.0.tgz",
+      "integrity": "sha512-KYx81rVE4LDbZcHfE375NCX4CDeZuz7HECZm/KAmqKMY2jpD3ZcUnI7Fm+QX5EMF/xmtzzfrNL/BNxo8o0iOQg==",
       "requires": {
-        "bech32": "^1.1.2",
-        "bigi": "^1.4.0",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.3.0",
-        "bs58check": "^2.0.0",
+        "bech32": "^2.0.0",
+        "bip174": "^2.0.1",
+        "bs58check": "^2.1.2",
         "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "ecurve": "^1.0.0",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
         "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
+        "varuint-bitcoin": "^1.1.2",
         "wif": "^2.0.1"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        }
       }
     },
     "bn.js": {
@@ -399,12 +393,13 @@
       }
     },
     "bs58check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
-      "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "requires": {
         "bs58": "^4.0.0",
-        "create-hash": "^1.1.0"
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "buffer-xor": {
@@ -711,15 +706,6 @@
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4"
-      }
-    },
-    "ecurve": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
-      "requires": {
-        "bigi": "^1.1.0",
-        "safe-buffer": "^5.0.1"
       }
     },
     "elliptic": {
@@ -2024,11 +2010,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "merkle-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -2525,22 +2506,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "pushdata-bitcoin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-      "requires": {
-        "bitcoin-ops": "^1.3.0"
-      }
-    },
-    "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "re-emitter": {
       "version": "1.1.3",
@@ -3253,9 +3218,9 @@
       }
     },
     "typeforce": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.12.0.tgz",
-      "integrity": "sha512-fvnkvueAOFLhtAqDgIA/wMP21SMwS/NQESFKZuwVrj5m/Ew6eK2S0z0iB++cwtROPWDOhaT6OUfla8UwMw4Adg=="
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "uniq": {
       "version": "1.0.1",
@@ -3301,9 +3266,9 @@
       }
     },
     "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
       "requires": {
         "safe-buffer": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@types/bn.js": "^4.11.3",
     "bech32": "^1.1.2",
-    "bitcoinjs-lib": "^3.3.1",
+    "bitcoinjs-lib": "^6.0.0",
     "bn.js": "^4.11.8",
     "create-hash": "^1.2.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bolt11",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A library for encoding and decoding lightning network payment requests as defined in [BOLT #11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md).",
   "main": "payreq.js",
   "types": "payreq.d.ts",

--- a/payreq.js
+++ b/payreq.js
@@ -5,7 +5,7 @@ const bech32 = require('bech32')
 const secp256k1 = require('secp256k1')
 const Buffer = require('safe-buffer').Buffer
 const BN = require('bn.js')
-const bitcoinjsAddress = require('bitcoinjs-lib/src/address')
+const bitcoinjsAddress = require('bitcoinjs-lib').address
 const cloneDeep = require('lodash/cloneDeep')
 
 // defaults for encode; default timestamp is current time at call

--- a/payreq.js
+++ b/payreq.js
@@ -14,25 +14,25 @@ const DEFAULTNETWORK = {
   bech32: 'bc',
   pubKeyHash: 0x00,
   scriptHash: 0x05,
-  validWitnessVersions: [0]
+  validWitnessVersions: [0, 1]
 }
 const TESTNETWORK = {
   bech32: 'tb',
   pubKeyHash: 0x6f,
   scriptHash: 0xc4,
-  validWitnessVersions: [0]
+  validWitnessVersions: [0, 1]
 }
 const REGTESTNETWORK = {
   bech32: 'bcrt',
   pubKeyHash: 0x6f,
   scriptHash: 0xc4,
-  validWitnessVersions: [0]
+  validWitnessVersions: [0, 1]
 }
 const SIMNETWORK = {
   bech32: 'sb',
   pubKeyHash: 0x3f,
   scriptHash: 0x7b,
-  validWitnessVersions: [0]
+  validWitnessVersions: [0, 1]
 }
 const DEFAULTEXPIRETIME = 3600
 const DEFAULTCLTVEXPIRY = 9

--- a/payreq.js
+++ b/payreq.js
@@ -232,6 +232,7 @@ function fallbackAddressParser (words, network) {
       address = bitcoinjsAddress.toBase58Check(addressHash, network.scriptHash)
       break
     case 0:
+    case 1:
       address = bitcoinjsAddress.toBech32(addressHash, version, network.bech32)
       break
   }
@@ -244,7 +245,7 @@ function fallbackAddressParser (words, network) {
 }
 
 // the code is the witness version OR 17 for P2PKH OR 18 for P2SH
-// anything besides code 17 or 18 should be bech32 encoded address.
+// anything besides code 17 or 18 should be bech32 or bech32m encoded address.
 // 1 word for the code, and right pad with 0 if necessary for the addressHash
 // (address parsing for encode is done in the encode function)
 function fallbackAddressEncoder (data, network) {

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -135,7 +135,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "complete": false,
           "satoshis": null,
@@ -165,7 +165,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "complete": false,
           "satoshis": null,
@@ -199,7 +199,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "complete": false,
           "satoshis": null,
@@ -234,7 +234,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -255,7 +255,7 @@
             "bech32": "bcrt",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -275,7 +275,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 2500000,
           "timestamp": 1496314658,
@@ -352,7 +352,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 2500000,
           "timestamp": 1496314658,
@@ -416,7 +416,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "recoveryFlag": 1,
           "signature": "6249c3a38d2a7d78f54f5494cf79fa06949e11eaf26ede32158f8a8e796ba1b741e88c35bec6bf5ee8291a5d50a7d35549e7fc564f7d0a39d1db5f098a0d179a",
@@ -443,7 +443,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -460,7 +460,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -478,7 +478,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "payeeNodeKey": "03000102030405060708090001020304050607080900010203040506070809ffff",
           "tags": [
@@ -504,7 +504,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -531,7 +531,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -558,7 +558,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -585,7 +585,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -612,7 +612,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -637,7 +637,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -670,7 +670,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -703,7 +703,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -736,7 +736,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -769,7 +769,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -802,7 +802,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -827,7 +827,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -852,7 +852,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "tags": [
             {
@@ -873,7 +873,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 23,
           "millisatoshis": "23000",
@@ -902,7 +902,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": null,
           "millisatoshis": null,
@@ -938,7 +938,7 @@
             "bech32": "tb",
             "pubKeyHash": 111,
             "scriptHash": 196,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 100,
           "millisatoshis": "200000",
@@ -962,7 +962,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 2500000,
           "timestamp": 1496314658,
@@ -989,7 +989,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 2500000,
           "timestamp": 1496314658,
@@ -1026,7 +1026,7 @@
             "bech32": "bc",
             "pubKeyHash": 0,
             "scriptHash": 5,
-            "validWitnessVersions": [0]
+            "validWitnessVersions": [0, 1]
           },
           "satoshis": 2500000,
           "timestamp": 1496314658,
@@ -1067,7 +1067,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc",
         "complete": true,
@@ -1096,7 +1096,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc2500u",
         "complete": true,
@@ -1164,7 +1164,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc20m",
         "complete": true,
@@ -1193,7 +1193,7 @@
           "bech32": "tb",
           "pubKeyHash": 111,
           "scriptHash": 196,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lntb20m",
         "complete": true,
@@ -1230,7 +1230,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc20m",
         "complete": true,
@@ -1286,7 +1286,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc20m",
         "complete": true,
@@ -1323,7 +1323,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc20m",
         "complete": true,
@@ -1360,7 +1360,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc20m",
         "complete": true,
@@ -1397,7 +1397,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [0]
+          "validWitnessVersions": [0, 1]
         },
         "prefix": "lnbc1230p",
         "complete": true,
@@ -1502,9 +1502,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [
-            0
-          ]
+          "validWitnessVersions": [0, 1]
         },
         "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
         "paymentRequest": "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqxqrrsssp5llllllllllllka84f5nflcsxhec4qq8efkkqvlguqj5v5wedku6q9q9zpsqqdqqcqpf4kkf33geaaxs0nkyr6l2jqgdy0np6dtf5t73m8wzp4qqlzga37px45ekvs4pdxtlppekh05073elkfcwtrc5dtlkhzcsa3c035pa4mqpr5xjms",
@@ -1604,9 +1602,7 @@
           "bech32": "bc",
           "pubKeyHash": 0,
           "scriptHash": 5,
-          "validWitnessVersions": [
-            0
-          ]
+          "validWitnessVersions": [0, 1]
         },
         "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
         "paymentRequest": "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqxqrrss9qpzdqqcqpfpxgg7ymvwywwk4c5jmau65tt6vladd5z4cyvt5t48rkhc2e8v2txfmzhqdrzhet7rmfvcmkdycr5ecc0h8azkyn6hnnkg242f4wfcsqpj9a4zg",

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -518,7 +518,7 @@
             {
               "tagName": "fallback_address",
               "data": {
-                "address": "tb1dqqqsyqcyq5rqwzqfpg9scrgwpuqsyqcyy5mynw"
+                "address": "tb1zx93njcnp8qcnqde4vgckydpkv33rsdnpxccrwetp8qmn2vnrv4jnjdfs8q6rsdpksh0hkj"
               }
             }
           ]

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1392,6 +1392,43 @@
         "wordsTemp": "temp1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q28j0v3rwgy9pvjnd48ee2pl8xrpxysd5g44td63g6xcjcu003j3qe8878hluqlvl3km8rm92f5stamd3jw763n3hck0ct7p8wwj463cqxfgdr0"
       },
       {
+        "paymentRequest": "lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4prp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q8playrmszfzefw6txnt50qlsytzavn3jyn75fv09wms65sr3n39rygdynm0tr645tgj8le5hu6lnvfgn7hmuf0reenpm605n3p668usqc3r7fq",
+        "network": {
+          "bech32": "bc",
+          "pubKeyHash": 0,
+          "scriptHash": 5,
+          "validWitnessVersions": [0, 1]
+        },
+        "prefix": "lnbc20m",
+        "complete": true,
+        "satoshis": 2000000,
+        "millisatoshis": "2000000000",
+        "timestamp": 1496314658,
+        "timestampString": "2017-06-01T10:57:38.000Z",
+        "payeeNodeKey": "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
+        "signature": "387fd20f70124594bb4b34d74783f022c5d64e3224fd44b1e576e1aa40719c4a3221a49edeb1eab45a247fe697e6bf362513f5f7c4bc79ccc3bd3e938875a3f2",
+        "recoveryFlag": 0,
+        "tags": [
+          {
+            "tagName": "purpose_commit_hash",
+            "data": "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1"
+          },
+          {
+            "tagName": "payment_hash",
+            "data": "0001020304050607080900010203040506070809000102030405060708090102"
+          },
+          {
+            "tagName": "fallback_address",
+            "data": {
+              "code": 1,
+              "address": "bc1prp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qj0fj5d",
+              "addressHash": "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"
+            }
+          }
+        ],
+        "wordsTemp": "temp1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4prp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q8playrmszfzefw6txnt50qlsytzavn3jyn75fv09wms65sr3n39rygdynm0tr645tgj8le5hu6lnvfgn7hmuf0reenpm605n3p668usqpj3wxj"
+      },
+      {
         "paymentRequest": "lnbc1230p1pwpw4vhpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq8w3jhxaqxqrrsscqpfmmcvd29nucsnyapspmkpqqf65uedt4zvhqkstelrgyk4nfvwka38c3nlq06agjmazs9nr3uupxp6r0v0gzw4n26redc36urkqwxamqqqu7esys",
         "network": {
           "bech32": "bc",

--- a/test/index.js
+++ b/test/index.js
@@ -231,7 +231,7 @@ tape('can decode and encode payment request containing unknown tags', (t) => {
     bech32: 'tb',
     pubKeyHash: 0x6f,
     scriptHash: 0xc4,
-    validWitnessVersions: [0]
+    validWitnessVersions: [0, 1]
   })
   t.ok(decoded.complete === true)
 
@@ -258,7 +258,7 @@ tape('can decode unknown network payment request', (t) => {
     bech32: 'sb',
     pubKeyHash: 0x6f,
     scriptHash: 0xc4,
-    validWitnessVersions: [0]
+    validWitnessVersions: [0, 1]
   }
   const decoded = lnpayreq.decode(
     'lnsb1u1pwslkj8pp52u27w39645j24a0zfxnwytshxserjchdqt8nz8uwv9fp8wasxrhsdq' +


### PR DESCRIPTION
## Summary
 - update dependency for `bitcoinjs-lib` to `v6`
 - fix one broken test (see comment  for commit https://github.com/bitcoinjs/bolt11/commit/b34dd0a23d0a051f824eb4719477c5cb09ba4332)
 - parser now allows `fallback_address.code` to be 1
 - add unit tests for witness v1 `fallback_adress`

Closes: https://github.com/bitcoinjs/bolt11/issues/52