### PR TITLE
feat: make tags available directly

### DIFF
--- a/payreq.d.ts
+++ b/payreq.d.ts
@@ -45,7 +45,10 @@ type Network = {
 // Start exports
 export declare type TagData = string | number | RoutingInfo | FallbackAddress | FeatureBits;
 export declare type PaymentRequestObject = {
+  description?: string;
+  purposeCommitHash?: string;
   paymentRequest?: string;
+  paymentHash?: string;
   complete?: boolean;
   prefix?: string;
   wordsTemp?: string;

--- a/payreq.js
+++ b/payreq.js
@@ -991,18 +991,18 @@ function decode (paymentRequest, network) {
     finalResult = Object.assign(finalResult, { timeExpireDate, timeExpireDateString })
   }
 
-  let description
-  if (description = tags.find(t => t.tagName === "description")?.data) {
+  const description = tags.find(t => t.tagName === 'description')?.data
+  if (description) {
     finalResult = Object.assign(finalResult, { description })
   }
 
-  let paymentHash
-  if (paymentHash = tags.find(t => t.tagName === "payment_hash")?.data) {
+  const paymentHash = tags.find(t => t.tagName === 'payment_hash')?.data
+  if (paymentHash) {
     finalResult = Object.assign(finalResult, { paymentHash })
   }
 
-  let purposeCommitHash
-  if (purposeCommitHash = tags.find(t => t.tagName === "purpose_commit_hash")?.data) {
+  const purposeCommitHash = tags.find(t => t.tagName === 'purpose_commit_hash')?.data
+  if (purposeCommitHash) {
     finalResult = Object.assign(finalResult, { purposeCommitHash })
   }
 

--- a/payreq.js
+++ b/payreq.js
@@ -991,6 +991,21 @@ function decode (paymentRequest, network) {
     finalResult = Object.assign(finalResult, { timeExpireDate, timeExpireDateString })
   }
 
+  let description
+  if (description = tags.find(t => t.tagName === "description")?.data) {
+    finalResult = Object.assign(finalResult, { description })
+  }
+
+  let paymentHash
+  if (paymentHash = tags.find(t => t.tagName === "payment_hash")?.data) {
+    finalResult = Object.assign(finalResult, { paymentHash })
+  }
+
+  let purposeCommitHash
+  if (purposeCommitHash = tags.find(t => t.tagName === "purpose_commit_hash")?.data) {
+    finalResult = Object.assign(finalResult, { purposeCommitHash })
+  }
+
   return orderKeys(finalResult)
 }
 


### PR DESCRIPTION
Within Alby we currently rely on the https://www.npmjs.com/package/invoices lib but found upgrading several times unstable and would like to move to this lib instead.

There is currently a migration PR open: https://github.com/getAlby/lightning-browser-extension/pull/830 but we found it a bit cumbersome to access certain tags.
We now have to use `tags.find((t) => t.tagName === "description")?.data` instead of directly using a description key on the PaymentRequestObject (which was possible with the invoices lib).

This PR makes that easier.