### PR TITLE
Add 'bolt11 decode' command as excutable

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// Call bolt11 decode from the command line.
+
+const decode = require('./payreq').decode
+
+const [,, command, invoice] = process.argv
+
+if (command !== 'decode') {
+  throw new Error('Invalid command, expected "bolt11 decode <invoice>"')
+}
+
+const results = decode(invoice)
+
+console.log(JSON.stringify(results, null, 2))
+

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test": "npm run standard && npm run coverage",
     "unit": "tape test/*.js"
   },
+  "bin": {
+    "bolt11": "./bin.js"
+  },
   "devDependencies": {
     "nyc": "^15.0.0",
     "standard": "*",


### PR DESCRIPTION
Is there any interest in exposing any of the `payreq.js`'s exports as executables? 

I've found my self regularly opening a node repl then calling `require('bolt11').decode(<invoice>)` and thought it might be nice to add this small functionality to this lib. It's also nice to be able to easily pipe this into `jq` or other shell tools.

This PR only exposes the `decode` command but i'd be happy to do the rest if there is interest for them, although I do suspect `decode` is the most useful in this context.

To test this out yourself pull down my branch and run 
 ```sh
 $ npm link
$ bolt11 decode <invoice>
```